### PR TITLE
Campaign show if "Show only if targeting matches" option

### DIFF
--- a/src/components/dashboard/containers/ItemCommon/ItemCommon.js
+++ b/src/components/dashboard/containers/ItemCommon/ItemCommon.js
@@ -526,6 +526,20 @@ const campaignProps = ({
 														fullWidth
 													/>
 												</Grid>
+												<Grid item xs={12}>
+													<TextField
+														// type='text'
+														value={
+															item.minTargetingScore
+																? t('CONFIRM_YES')
+																: t('CONFIRM_NO')
+														}
+														label={t('CAMPAIGN_MIN_TARGETING')}
+														disabled
+														margin='dense'
+														fullWidth
+													/>
+												</Grid>
 											</Grid>
 										</Grid>
 									</Grid>

--- a/src/components/dashboard/containers/ItemHoc/ItemHoc.js
+++ b/src/components/dashboard/containers/ItemHoc/ItemHoc.js
@@ -534,7 +534,7 @@ export default function ItemHoc(Decorated) {
 		return {
 			account: persist.account,
 			item: item,
-			validateId: 'update-' + (item.id || item.ipfs),
+			validateId: 'update-' + (item && (item.id || item.ipfs)),
 			matchId: id,
 		}
 	}


### PR DESCRIPTION
- Show if "Show only if targeting matches" option was chosen for an ad unit (fixes #224)
- fixes application crash if invalid Item id provided in URL